### PR TITLE
pin version of prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "custom-card-helpers": "^1.9.0",
         "home-assistant-js-websocket": "^9.4.0",
         "liquidjs": "^10.16.7",
+        "prettier": "^3.3.3",
         "typedoc": "^0.26.6",
         "typescript": "^5.5.4",
         "vite": "^5.4.3",
@@ -1187,6 +1188,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode.js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "custom-card-helpers": "^1.9.0",
     "home-assistant-js-websocket": "^9.4.0",
     "liquidjs": "^10.16.7",
+    "prettier": "^3.3.3",
     "typedoc": "^0.26.6",
     "typescript": "^5.5.4",
     "vite": "^5.4.3",


### PR DESCRIPTION
Since the workflow now involves calling Prettier, it should be pinned to a specific version.

## Technical Changes

<!--- You need to check this checkbox for the correct workflow if your change is purely technical -->

-   [x] 🛠 Purely Technical Changes (Performance Improvements, Stability Improvements, etc.)

## Breaking

<!--- Is your addition a Breaking Change? (= fix or feature that would cause existing functionality to change) -->
<!--- Does it maybe change the "YAML Interface" the end user interacts with or change? -->
<!--- Or does it change what is happening in the 'end product' dashboard of the users? -->
<!--- Or anything else? -->

-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Development (Check all)

-   [x] My code follows the code style of this project (I used the Prettier config).
-   [x] I have tested the change locally.

### Documentation (Pick one)

-   [ ] I have checked that the documentation will update automatically from my code (npm run typedoc).
-   [ ] I have manually updated the documentation accordingly (files in /src/doc_snippets!).
-   [x] My change requires no changes to the documentation.
